### PR TITLE
fix(nodejs): fix oauth client to add auth. before the domain

### DIFF
--- a/packages/examples/nodejs/package.json
+++ b/packages/examples/nodejs/package.json
@@ -2,7 +2,7 @@
   "name": "@vm-x-ai/sdk/examples/nodejs",
   "version": "0.0.1",
   "dependencies": {
-    "@vm-x-ai/client": "1.0.0",
+    "@vm-x-ai/client": "1.0.1",
     "tslib": "^2.3.0"
   },
   "type": "module",

--- a/packages/nodejs/src/auth/oauth.ts
+++ b/packages/nodejs/src/auth/oauth.ts
@@ -37,7 +37,7 @@ export class VMXClientOAuth<TCacheStore extends Store = MemoryStore> implements 
     }
 
     const response = await axios.post(
-      `https://${domain}/oauth2/token`,
+      `https://auth.${domain}/oauth2/token`,
       {
         grant_type: 'client_credentials',
         client_id: this.options.clientId,


### PR DESCRIPTION
This PR fixes the Node.js SDK to add `auth.` before the domain in the OAuth client credentials authentication flow.