### PR TITLE
ci: remove unnecessary pnpm cache steps from github actions

### DIFF
--- a/.github/actions/setup-monorepo/action.yml
+++ b/.github/actions/setup-monorepo/action.yml
@@ -23,19 +23,6 @@ runs:
         node-version: 20
         cache: 'pnpm'
 
-    - name: Get pnpm store directory
-      shell: bash
-      run: |
-        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-    - uses: actions/cache@v3
-      name: Setup pnpm cache
-      with:
-        path: ${{ env.STORE_PATH }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-store-
-
     - name: Install Node.js Dependencies
       shell: bash
       run: pnpm install


### PR DESCRIPTION
This PR removes 2 unnecessary steps from the GitHub actions setup monorepo flow.